### PR TITLE
Added option for no support structure on OpenLOCK bases

### DIFF
--- a/MakeTile/tile_creation/Curved_Tiles.py
+++ b/MakeTile/tile_creation/Curved_Tiles.py
@@ -774,7 +774,10 @@ def spawn_openlock_base_clip_cutter(self, base, tile_props):
         cutter_file)
 
     with bpy.data.libraries.load(booleans_path) as (data_from, data_to):
-        data_to.objects = ['openlock.wall.base.cutter.clip_single']
+        if self.base_socket_type == 'OPENLOCK':
+            data_to.objects = ['openlock.wall.base.cutter.clip_single']
+        elif self.base_socket_type == 'OPENLOCK-NoSupport':
+           data_to.objects = ['openlock.wall.base.cutter.clip_single.nosupp']
 
     clip_cutter = data_to.objects[0]
     add_object_to_collection(clip_cutter, tile_props.tile_name)

--- a/MakeTile/tile_creation/L_Tiles.py
+++ b/MakeTile/tile_creation/L_Tiles.py
@@ -972,10 +972,16 @@ def spawn_openlock_base(self, tile_props):
 
     # load base cutters
     with bpy.data.libraries.load(booleans_path) as (data_from, data_to):
-        data_to.objects = [
-            'openlock.wall.base.cutter.clip.001',
-            'openlock.wall.base.cutter.clip.cap.start.001',
-            'openlock.wall.base.cutter.clip.cap.end.001']
+        if self.base_socket_type == 'OPENLOCK':
+            data_to.objects = [
+                'openlock.wall.base.cutter.clip.001',
+                'openlock.wall.base.cutter.clip.cap.start.001',
+                'openlock.wall.base.cutter.clip.cap.end.001']
+        elif self.base_socket_type == 'OPENLOCK-NoSupport':
+            data_to.objects = [
+                'openlock.wall.base.cutter.clip.001.nosupp',
+                'openlock.wall.base.cutter.clip.cap.start.001',
+                'openlock.wall.base.cutter.clip.cap.end.001']
 
     clip_cutter = data_to.objects[0]
     cutter_start_cap = data_to.objects[1]

--- a/MakeTile/tile_creation/Semi_Circ_Tiles.py
+++ b/MakeTile/tile_creation/Semi_Circ_Tiles.py
@@ -515,10 +515,16 @@ def create_openlock_base_clip_cutters(self, tile_props):
 
     if radius >= 1:
         with bpy.data.libraries.load(booleans_path) as (data_from, data_to):
-            data_to.objects = [
-                'openlock.wall.base.cutter.clip.001',
-                'openlock.wall.base.cutter.clip.cap.start.001',
-                'openlock.wall.base.cutter.clip.cap.end.001']
+            if self.base_socket_type == 'OPENLOCK':
+                data_to.objects = [
+                    'openlock.wall.base.cutter.clip.001',
+                    'openlock.wall.base.cutter.clip.cap.start.001',
+                    'openlock.wall.base.cutter.clip.cap.end.001']
+            elif self.base_socket_type == 'OPENLOCK-NoSupport':
+                data_to.objects = [
+                    'openlock.wall.base.cutter.clip.001.nosupp',
+                    'openlock.wall.base.cutter.clip.cap.start.001',
+                    'openlock.wall.base.cutter.clip.cap.end.001']
         '''
         for obj in data_to.objects:
             add_object_to_collection(obj, tile_props.tile_name)

--- a/MakeTile/tile_creation/Straight_Tiles.py
+++ b/MakeTile/tile_creation/Straight_Tiles.py
@@ -922,11 +922,17 @@ def spawn_openlock_base_clip_cutters(self, base, tile_props):
             cutter_file)
 
         with bpy.data.libraries.load(booleans_path) as (data_from, data_to):
-            data_to.objects = [
-                'openlock.wall.base.cutter.clip',
-                'openlock.wall.base.cutter.clip.cap.start',
-                'openlock.wall.base.cutter.clip.cap.end']
-
+            if self.base_socket_type == 'OPENLOCK':
+                data_to.objects = [
+                    'openlock.wall.base.cutter.clip',
+                    'openlock.wall.base.cutter.clip.cap.start',
+                    'openlock.wall.base.cutter.clip.cap.end']
+            elif self.base_socket_type == 'OPENLOCK-NoSupport':
+                data_to.objects = [
+                    'openlock.wall.base.cutter.clip.nosupp',
+                    'openlock.wall.base.cutter.clip.cap.start',
+                    'openlock.wall.base.cutter.clip.cap.end']
+                
         for obj in data_to.objects:
             add_object_to_collection(obj, tile_props.tile_name)
 

--- a/MakeTile/tile_creation/Triangular_Tiles.py
+++ b/MakeTile/tile_creation/Triangular_Tiles.py
@@ -416,10 +416,16 @@ def spawn_openlock_base_clip_cutters(self, dimensions, tile_props):
 
         cutters = []
         with bpy.data.libraries.load(booleans_path) as (data_from, data_to):
-            data_to.objects = [
-                'openlock.wall.base.cutter.clip.001',
-                'openlock.wall.base.cutter.clip.cap.start.001',
-                'openlock.wall.base.cutter.clip.cap.end.001']
+            if self.base_socket_type == 'OPENLOCK':
+                data_to.objects = [
+                    'openlock.wall.base.cutter.clip.001',
+                    'openlock.wall.base.cutter.clip.cap.start.001',
+                    'openlock.wall.base.cutter.clip.cap.end.001']
+            elif self.base_socket_type == 'OPENLOCK-NoSupport':
+                data_to.objects = [
+                    'openlock.wall.base.cutter.clip.001.nosupp',
+                    'openlock.wall.base.cutter.clip.cap.start.001',
+                    'openlock.wall.base.cutter.clip.cap.end.001']
 
         cutter = data_to.objects[0]
         cutter_start_cap = data_to.objects[1]

--- a/MakeTile/tile_creation/U_Tiles.py
+++ b/MakeTile/tile_creation/U_Tiles.py
@@ -698,12 +698,12 @@ def spawn_openlock_base(self, tile_props):
 
     # clip cutters
     clip_cutter_leg_1 = spawn_openlock_base_clip_cutter(self, tile_props)
-    clip_cutter_leg_1.name = 'Leg 1 Clip.' + tile_props.name + '.clip_cutter'
+    clip_cutter_leg_1.name = 'Leg 1 Clip.' + tile_props.tile_name + '.clip_cutter'
     clip_cutter_leg_2 = clip_cutter_leg_1.copy()
-    clip_cutter_leg_2.name = 'Leg 2 Clip.' + tile_props.name + '.clip_cutter'
+    clip_cutter_leg_2.name = 'Leg 2 Clip.' + tile_props.tile_name + '.clip_cutter'
     clip_cutter_leg_2.data = clip_cutter_leg_2.data.copy()
     clip_cutter_x_leg = clip_cutter_leg_1.copy()
-    clip_cutter_x_leg.name = 'End Wall Clip.' + tile_props.name + '.clip_cutter'
+    clip_cutter_x_leg.name = 'End Wall Clip.' + tile_props.tile_name + '.clip_cutter'
     clip_cutter_x_leg.data = clip_cutter_x_leg.data.copy()
 
     cutters = [clip_cutter_leg_1, clip_cutter_leg_2, clip_cutter_x_leg]
@@ -857,10 +857,16 @@ def spawn_openlock_base_clip_cutter(self, tile_props):
 
     # load base cutters
     with bpy.data.libraries.load(booleans_path) as (data_from, data_to):
-        data_to.objects = [
-            'openlock.wall.base.cutter.clip',
-            'openlock.wall.base.cutter.clip.cap.start',
-            'openlock.wall.base.cutter.clip.cap.end']
+        if self.base_socket_type == 'OPENLOCK':
+            data_to.objects = [
+                'openlock.wall.base.cutter.clip',
+                'openlock.wall.base.cutter.clip.cap.start',
+                'openlock.wall.base.cutter.clip.cap.end']
+        elif self.base_socket_type == 'OPENLOCK-NoSupport':
+            data_to.objects = [
+                'openlock.wall.base.cutter.clip.nosupp',
+                'openlock.wall.base.cutter.clip.cap.start',
+                'openlock.wall.base.cutter.clip.cap.end']
 
     for obj in data_to.objects:
         add_object_to_collection(obj, tile_props.tile_name)

--- a/MakeTile/tile_creation/create_tile.py
+++ b/MakeTile/tile_creation/create_tile.py
@@ -467,6 +467,7 @@ class MT_Tile_Generator:
     base_socket_type: EnumProperty(
         items=[
             ("OPENLOCK", "OpenLOCK", ""),
+            ("OPENLOCK-NoSupport", "OpenLOCK-NoSupport", ""),
             ("LASTLOCK", "LastLOCK", "")],
         default="OPENLOCK",
         name="Base socket type",
@@ -590,6 +591,8 @@ class MT_Tile_Generator:
         """
         sockets = [
             {'socket_type': 'OPENLOCK',
+             'filename': 'openlock.blend'},
+            {'socket_type': 'OPENLOCK-NoSupport',
              'filename': 'openlock.blend'},
             {'socket_type': 'LASTLOCK',
              'filename': 'lastlock.blend'}]


### PR DESCRIPTION
1. Added option for no support structure on OpenLOCK bases. This is based on PR #67 on the original MakeTile repo by user [Trainzack](https://github.com/Trainzack).
2. Updated included .blend file to cover new support-less cutters.